### PR TITLE
fix for boss_valithria_dreamwalker.cpp(700): warning C4715: 

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -691,7 +691,7 @@ class npc_risen_archmage : public CreatureScript
             {
             }
 
-            bool CanAIAttack(Unit const* target) const
+            bool CanAIAttack(Unit const* target) //const
             {
                 if(_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED || _instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == FAIL)
                     return target->GetEntry() != NPC_VALITHRIA_DREAMWALKER;


### PR DESCRIPTION
boss_valithria_dreamwalker.cpp(700): warning C4715: 'npc_risen_archmage::npc_risen_archmageAI::CanAIAttack' : not all control paths return a value
