### PR TITLE
fox for sc_npc_teleport.cpp(150): warning C4018: '>=' : signed/unsigned ...

### DIFF
--- a/src/server/game/AI/ScriptedAI/sc_npc_teleport.h
+++ b/src/server/game/AI/ScriptedAI/sc_npc_teleport.h
@@ -84,7 +84,7 @@ namespace nsNpcTel
         std::string m_name;
         Flag        m_flag;
         uint64      m_data0;
-        uint32      m_data1;
+        uint64      m_data1;
         VDest       m_TabDest;
     };
 


### PR DESCRIPTION
fox for sc_npc_teleport.cpp(150): warning C4018: '>=' : signed/unsigned ...
