### PR TITLE
fix for hunterpet_vendor.cpp(51): warning C4005: 'main' : macro redefini...

### DIFF
--- a/src/server/scripts/Custom/hunterpet_vendor.cpp
+++ b/src/server/scripts/Custom/hunterpet_vendor.cpp
@@ -48,7 +48,7 @@ enum Creatures
         CREATURE_ARCTURIS                                       = 38453,
 };
  
-#define main    100
+//#define main    100
 #define pets    200
 #define exotic  300
 // Pets


### PR DESCRIPTION
hunterpet_vendor.cpp(51): warning C4005: 'main' : macro redefinition
that is already define in OS_main.h
